### PR TITLE
スピーカーの画像不要に伴うソース削除

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -72,19 +72,8 @@ h2 {
 .map__wrap iframe {
   width: 100%;
 }
-.box__wrap {
-  display: flex;
-  flex-wrap: wrap;
-}
 .box__wrap + .box__wrap {
   margin-top: 25px;
-}
-.speaker__icon {
-  width: 20%;
-}
-.speaker__profile {
-  width: 78%;
-  margin-left: 2%;
 }
 .speaker__profile h3 {
   margin-bottom: 10px;

--- a/index.html
+++ b/index.html
@@ -27,14 +27,12 @@
     <div class="inner">
       <h2>スピーカー</h2>
       <div class="box__wrap">
-        <div class="speaker__icon"></div>
         <div class="speaker__profile">
           <h3>未定</h3>
           <p>ダミーダミーダミーダミーダミーダミーダミーダミーダミー</p>
         </div>
       </div>
       <div class="box__wrap">
-        <div class="speaker__icon"></div>
         <div class="speaker__profile">
           <h3>未定</h3>
           <p>ダミーダミーダミーダミーダミーダミーダミーダミーダミー</p>


### PR DESCRIPTION
### 変更内容
スピーカー項目の画像関連ソース削除
### 背景
スピーカーに仮で配置していた画像が掲載不要となったため、関連するソースを全て削除